### PR TITLE
JSON file reading feature addition

### DIFF
--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -36,3 +36,13 @@ type = "dotenv"
 # be searched for to retrieve the var1 value
 var1 = {path = [], name = "VAR_1"}
 var2 = {path = [], name = "VAR_2"}
+json_var = {path = [[], "jsonMap"], type = "json", name = "VAR_3"}
+
+[from_json]
+path = "./test_files/json_map.json"
+[from_json.vars]
+var1.path = []
+var2.path = []
+var3.path = []
+var4.path = [[], "nested_object"]
+

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -31,7 +31,7 @@ Options:
   --out=<type>     Configuration output type [default: json].
                    Valid types: json, toml, yaml, dotenv, raw.`
 
-	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.0")
+	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.4.1")
 	var conf struct {
 		Gen      bool
 		Ctx      string

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -31,7 +31,7 @@ Options:
   --out=<type>     Configuration output type [default: json].
                    Valid types: json, toml, yaml, dotenv, raw.`
 
-	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.4.1")
+	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.0")
 	var conf struct {
 		Gen      bool
 		Ctx      string

--- a/generate.go
+++ b/generate.go
@@ -103,22 +103,24 @@ func (g *Gear) ResolveMap(env RawEnv) (map[string]string, error) {
 		}
 	}
 
-	for path, pathGroup := range pathGroups {
+	for p, pGroup := range pathGroups {
 		// 2. for each distinct Path: generate a Reader object
-		cfgFilePath := g.getCfgFilePath(path)
-		fileBuf, err := pathGroup.loadFile(cfgFilePath)
+		cfgFilePath := g.getCfgFilePath(p)
+		fileBuf, err := pGroup.loadFile(cfgFilePath)
 		if err != nil {
 			return nil, err
 		}
 
 		// 3. create yaml visitor to handle SubPath strings
+		if path.Ext(cfgFilePath) == "json" {
+		}
 		visitor, err := NewYamlVisitor(fileBuf)
 		if err != nil {
 			return nil, err
 		}
 
 		// 4. traverse every Path and possible SubPath retrieving the Cfg.Values associated with it
-		for _, cfg := range pathGroup.cfgs {
+		for _, cfg := range pGroup.cfgs {
 			err := visitor.SetValue(cfg)
 			if err != nil {
 				return nil, err
@@ -368,7 +370,7 @@ func parseCfgMap(varName string, baseCfg *Cfg, cfgVal map[string]interface{}) (*
 // 3. path value  is a two index slice with either index possibly holding an empty slice or string value:
 // -  [[], subpath] - path will be inherited from baseCfg if present
 // -  [path, []] - subpath will be inherited from baseCfg if present
-// -  [path, subpath] - nothing will be inherited as both indices hold strings
+// 4. [path, subpath] - nothing will be inherited as both indices hold strings
 func decodePath(v interface{}, cfg *Cfg, baseCfg *Cfg) error {
 	var ok bool
 	var baseCfgSlice []string

--- a/test_files/json_map.json
+++ b/test_files/json_map.json
@@ -1,0 +1,8 @@
+{
+  "var1": "var1_value",
+  "var2": "var2_value",
+  "var3": "var3_value",
+  "nested_object": {
+    "var4": "var4_value"
+  }
+}

--- a/test_files/kustomization.yaml
+++ b/test_files/kustomization.yaml
@@ -3,4 +3,5 @@ configMapGenerator:
     literals:
       - VAR_1=var1_value
       - VAR_2=var2_value
-
+jsonMap: |
+  { "VAR_3": "var3_value" }


### PR DESCRIPTION
* Add COGS support for JSON file deserialization
* Add COGS support for JSON `readType` deserialization

Biggest caveats here is that JSON is unmarshalled to `map[string]interface{}` and then encoded to `yaml.Node` meaning that `yq` syntax is used to traverse a JSON object. Whether this is a good or bad idea remains to be seen but it does give us the shortest path to integrating JSON files into cogs

Test commands:
JSON file reading: `cogs gen from_json basic.cog.toml`
JSON nested in YAML: `cogs gen kustomize basic.cog.toml`