### PR TITLE
Complex json deserialization

### DIFF
--- a/advanced.cog.toml
+++ b/advanced.cog.toml
@@ -1,0 +1,24 @@
+name = "advanced_service"
+
+# this example mainly deals with how one handles JSON data embedded in another format
+# or as a proper JSON file
+[flat_json]
+path = ["./test_files/json_map.json", "valid_flat_map"]
+[flat_json.vars]
+var1.path = []
+var2.path = []
+var3.path = []
+var4.path = [[], "var4_complex.nested"]
+
+[complex_json]
+path = ["./test_files/json_map.json", "valid_flat_map"]
+[complex_json.vars]
+var1.path = []
+var2.path = []
+var3.path = []
+# '[[], ""]' retains "./test_files/json_map.json" in [] reference in index 0
+# and "" in index 1 disables object traversal
+var4 = {path = [[], ""], name = "var4_complex", type = "json{}"}
+# returns file in entirety as value for k/v pair
+entire_file = {path = [[], ""], type = "whole"}
+

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -37,24 +37,3 @@ type = "dotenv"
 var1 = {path = [], name = "VAR_1"}
 var2 = {path = [], name = "VAR_2"}
 json_var = {path = [[], "jsonMap"], type = "json", name = "VAR_3"}
-
-[flat_json]
-path = ["./test_files/json_map.json", "valid_flat_map"]
-[flat_json.vars]
-var1.path = []
-var2.path = []
-var3.path = []
-var4.path = [[], "var4_complex.nested"]
-
-[complex_json]
-path = ["./test_files/json_map.json", "valid_flat_map"]
-[complex_json.vars]
-var1.path = []
-var2.path = []
-var3.path = []
-# '[[], ""]' retains "./test_files/json_map.json" in [] reference in index 0
-# and "" in index 1 disables object traversal
-var4 = {path = [[], ""], name = "var4_complex", type = "json{}"}
-# returns file in entirety as value for k/v pair
-entire_file = {path = [[], ""], type = "whole"}
-

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -39,18 +39,22 @@ var2 = {path = [], name = "VAR_2"}
 json_var = {path = [[], "jsonMap"], type = "json", name = "VAR_3"}
 
 [flat_json]
-path = "./test_files/json_map.json"
+path = ["./test_files/json_map.json", "valid_flat_map"]
 [flat_json.vars]
 var1.path = []
 var2.path = []
 var3.path = []
-var4.path = [[], "nested"]
+var4.path = [[], "var4_complex.nested"]
 
 [complex_json]
-path = "./test_files/json_map.json"
+path = ["./test_files/json_map.json", "valid_flat_map"]
 [complex_json.vars]
 var1.path = []
 var2.path = []
 var3.path = []
-var4= {path = [[], "nested"], type = "json{}"}
+# '[[], ""]' retains "./test_files/json_map.json" in [] reference in index 0
+# and "" in index 1 disables object traversal
+var4 = {path = [[], ""], name = "var4_complex", type = "json{}"}
+# returns file in entirety as value for k/v pair
+entire_file = {path = [[], ""], type = "whole"}
 

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -38,11 +38,19 @@ var1 = {path = [], name = "VAR_1"}
 var2 = {path = [], name = "VAR_2"}
 json_var = {path = [[], "jsonMap"], type = "json", name = "VAR_3"}
 
-[from_json]
+[flat_json]
 path = "./test_files/json_map.json"
-[from_json.vars]
+[flat_json.vars]
 var1.path = []
 var2.path = []
 var3.path = []
-var4.path = [[], "nested_object"]
+var4.path = [[], "nested"]
+
+[complex_json]
+path = "./test_files/json_map.json"
+[complex_json.vars]
+var1.path = []
+var2.path = []
+var3.path = []
+var4= {path = [[], "nested"], type = "json{}"}
 

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -36,3 +36,13 @@ type = "dotenv"
 # be searched for to retrieve the var1 value
 var1 = {path = [], name = "VAR_1"}
 var2 = {path = [], name = "VAR_2"}
+json_var = {path = [[], "jsonMap"], type = "json", name = "VAR_3"}
+
+[from_json]
+path = "./test_files/json_map.json"
+[from_json.vars]
+var1.path = []
+var2.path = []
+var3.path = []
+var4.path = [[], "nested_object"]
+

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -51,7 +51,7 @@ Options:
 	cogs.EnvSubst = conf.EnvSubst
 
 	// filterCfgMap retains only key names passed to --keys
-	filterCfgMap := func(cfgMap map[string]string) (map[string]string, error) {
+	filterCfgMap := func(cfgMap map[string]interface{}) (map[string]interface{}, error) {
 
 		// --not runs before --keys!
 		// make sure to avoid --not=key_name --key=key_name, ya dingus!
@@ -65,7 +65,7 @@ Options:
 		}
 
 		keyList := strings.Split(conf.Keys, ",")
-		newCfgMap := make(map[string]string)
+		newCfgMap := make(map[string]interface{})
 		for _, key := range keyList {
 			var ok bool
 			newCfgMap[key], ok = cfgMap[key]

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -31,7 +31,7 @@ Options:
   --out=<type>     Configuration output type [default: json].
                    Valid types: json, toml, yaml, dotenv, raw.`
 
-	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.0")
+	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.1")
 	var conf struct {
 		Gen      bool
 		Ctx      string

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -31,7 +31,7 @@ Options:
   --out=<type>     Configuration output type [default: json].
                    Valid types: json, toml, yaml, dotenv, raw.`
 
-	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.1")
+	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.0")
 	var conf struct {
 		Gen      bool
 		Ctx      string

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -31,7 +31,7 @@ Options:
   --out=<type>     Configuration output type [default: json].
                    Valid types: json, toml, yaml, dotenv, raw.`
 
-	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.4.1")
+	opts, _ := docopt.ParseArgs(usage, os.Args[1:], "0.5.0")
 	var conf struct {
 		Gen      bool
 		Ctx      string

--- a/cmd/cogs/optparse.go
+++ b/cmd/cogs/optparse.go
@@ -17,27 +17,27 @@ func ifErr(err error) {
 	}
 }
 
-func getRawValue(cfgMap map[string]string) string {
+func getRawValue(cfgMap map[string]interface{}) string {
 	output := ""
 	// for now, no delimiter
 	for _, v := range cfgMap {
-		output = output + v
+		output = output + fmt.Sprintf("%s", v)
 	}
 	return output
 
 }
 
-func upperKeys(cfgMap map[string]string) map[string]string {
+func upperKeys(cfgMap map[string]interface{}) map[string]string {
 	newCfgMap := make(map[string]string)
 	for k, v := range cfgMap {
-		newCfgMap[strings.ToUpper(k)] = v
+		newCfgMap[strings.ToUpper(k)] = fmt.Sprintf("%s", v)
 	}
 	return newCfgMap
 }
 
 // exclude produces a laundered map with exclusionList values misssing
-func exclude(exclusionList []string, cfgMap map[string]string) map[string]string {
-	newCfgMap := make(map[string]string)
+func exclude(exclusionList []string, cfgMap map[string]interface{}) map[string]interface{} {
+	newCfgMap := make(map[string]interface{})
 	for k, _ := range cfgMap {
 		if inList(k, exclusionList) {
 			continue

--- a/cmd/cogs/optparse.go
+++ b/cmd/cogs/optparse.go
@@ -27,6 +27,8 @@ func getRawValue(cfgMap map[string]interface{}) string {
 
 }
 
+// upperKeys should always return a flat associative array of strings
+// coercing any interface{} value into a string
 func upperKeys(cfgMap map[string]interface{}) map[string]string {
 	newCfgMap := make(map[string]string)
 	for k, v := range cfgMap {

--- a/cmd/cogs/optparse.go
+++ b/cmd/cogs/optparse.go
@@ -38,7 +38,7 @@ func upperKeys(cfgMap map[string]interface{}) map[string]string {
 // exclude produces a laundered map with exclusionList values misssing
 func exclude(exclusionList []string, cfgMap map[string]interface{}) map[string]interface{} {
 	newCfgMap := make(map[string]interface{})
-	for k, _ := range cfgMap {
+	for k := range cfgMap {
 		if inList(k, exclusionList) {
 			continue
 		}

--- a/decrypt.go
+++ b/decrypt.go
@@ -1,14 +1,15 @@
 package cogs
 
 import (
-    "fmt"
-    "go.mozilla.org/sops/v3/decrypt"
+	"fmt"
+
+	"go.mozilla.org/sops/v3/decrypt"
 )
 
 func decryptFile(filePath string) ([]byte, error) {
-    sec, err := decrypt.File(filePath, "yaml")
-    if err != nil {
-        return nil, fmt.Errorf("cannot decrypt file: %s", err)
-    }
-    return sec, nil
+	sec, err := decrypt.File(filePath, "yaml")
+	if err != nil {
+		return nil, fmt.Errorf("cannot decrypt file: %s", err)
+	}
+	return sec, nil
 }

--- a/file.go
+++ b/file.go
@@ -160,6 +160,20 @@ func (n *yamlVisitor) SetValue(cfg *Cfg) (err error) {
 		return nil
 	}
 
+	// if SubPath is an empty string, grab the top level value that corresponds
+	// to a key with the string value of cfg.Name and attempt to assign it
+	// to cfg.Value by calling node.Decode
+	if cfg.SubPath == "" {
+		node, err := n.get(cfg.Name)
+		if err != nil {
+			return err
+		}
+		err = node.Decode(&cfg.Value)
+		if err != nil {
+			return err
+		}
+	}
+
 	// check if cfg.SubPath value has been used in a previous SetValue call
 	if valMap, ok := n.cachedNodes[cfg.SubPath]; ok {
 		cfg.Value, ok = valMap[cfg.Name]

--- a/file.go
+++ b/file.go
@@ -160,20 +160,6 @@ func (n *yamlVisitor) SetValue(cfg *Cfg) (err error) {
 		return nil
 	}
 
-	// if SubPath is an empty string, grab the top level value that corresponds
-	// to a key with the string value of cfg.Name and attempt to assign it
-	// to cfg.Value by calling node.Decode
-	if cfg.SubPath == "" {
-		node, err := n.get(cfg.Name)
-		if err != nil {
-			return err
-		}
-		err = node.Decode(&cfg.Value)
-		if err != nil {
-			return err
-		}
-	}
-
 	// check if cfg.SubPath value has been used in a previous SetValue call
 	if valMap, ok := n.cachedNodes[cfg.SubPath]; ok {
 		cfg.Value, ok = valMap[cfg.Name]
@@ -183,6 +169,9 @@ func (n *yamlVisitor) SetValue(cfg *Cfg) (err error) {
 		return nil
 	}
 
+	// if SubPath is an empty string, grab the top level value that corresponds
+	// to a key with the string value of cfg.Name and attempt to assign it
+	// to cfg.Value by calling node.Decode
 	node, err := n.get(cfg.SubPath)
 	if err != nil {
 		return err

--- a/file.go
+++ b/file.go
@@ -16,8 +16,8 @@ type readType string
 
 const (
 	rDotenv      readType = "dotenv"
-	rJson        readType = "json"
-	rJsonComplex readType = "json{}"
+	rJSON        readType = "json"
+	rJSONComplex readType = "json{}"
 	rWhole       readType = "whole"
 	deferred     readType = "" // defer file config type to filename suffix
 )
@@ -27,9 +27,9 @@ func (t readType) Validate() error {
 	switch t {
 	case rDotenv:
 		return nil
-	case rJson:
+	case rJSON:
 		return nil
-	case rJsonComplex:
+	case rJSONComplex:
 		return nil
 	case rWhole:
 		return nil
@@ -42,9 +42,9 @@ func (t readType) String() string {
 	switch t {
 	case rDotenv:
 		return string(rDotenv)
-	case rJson:
-		return string(rJson)
-	case rJsonComplex:
+	case rJSON:
+		return string(rJSON)
+	case rJSONComplex:
 		return "complex json"
 	case rWhole:
 		return "complex json"
@@ -106,9 +106,9 @@ var kindStr = map[yaml.Kind]string{
 	yaml.AliasNode:    "AliasNode",
 }
 
-// NewJsonVisitor returns a visitor object that satisfies the Queryable interface
+// NewJSONVisitor returns a visitor object that satisfies the Queryable interface
 // attempting to turn a supposed JSON byte slice into a *yaml.Node object
-func NewJsonVisitor(buf []byte) (Queryable, error) {
+func NewJSONVisitor(buf []byte) (Queryable, error) {
 	visitor := &yamlVisitor{
 		rootNode:    &yaml.Node{},
 		cachedNodes: make(map[string]map[string]string),
@@ -187,13 +187,13 @@ func (n *yamlVisitor) SetValue(cfg *Cfg) (err error) {
 		if err != nil {
 			return err
 		}
-	case rJson:
-		cachedMap, err = visitJson(node)
+	case rJSON:
+		cachedMap, err = visitJSON(node)
 		if err != nil {
 			return err
 		}
 	// do not cache complex maps for now
-	case rJsonComplex:
+	case rJSONComplex:
 		complexMap := make(map[string]interface{})
 		err = node.Decode(&complexMap)
 		if err != nil {
@@ -249,7 +249,7 @@ func visitDotenv(node *yaml.Node) (map[string]string, error) {
 	return envMap, nil
 }
 
-func visitJson(node *yaml.Node) (map[string]string, error) {
+func visitJSON(node *yaml.Node) (map[string]string, error) {
 	var strEnv string
 
 	if err := node.Decode(&strEnv); err != nil {

--- a/generate.go
+++ b/generate.go
@@ -134,7 +134,6 @@ func (g *Gear) ResolveMap(env RawEnv) (map[string]interface{}, error) {
 	cfgOut := make(map[string]interface{})
 	for cogName, cfg := range g.cfgMap {
 		if cfg.ComplexValue != nil {
-			fmt.Printf("complex value: %s\n", cfg.ComplexValue)
 			cfgOut[cogName] = cfg.ComplexValue
 		} else {
 			cfgOut[cogName] = cfg.Value

--- a/generate.go
+++ b/generate.go
@@ -19,9 +19,10 @@ var EnvSubst bool = false
 
 // Cfg holds all the data needed to generate one string key value pair
 type Cfg struct {
-	// Defaults to key name unless explicitly declared
-	Name         string
-	Value        string
+	Name  string // Defaults to key name unless explicitly declared
+	Value string
+	// Cfg.ComplexValue should be  non empty when Cfg.Value is empty/""
+	// and vice versa
 	ComplexValue interface{}
 	Path         string
 	// default should be Cfg key name
@@ -133,6 +134,9 @@ func (g *Gear) ResolveMap(env RawEnv) (map[string]interface{}, error) {
 	// final output
 	cfgOut := make(map[string]interface{})
 	for cogName, cfg := range g.cfgMap {
+		if cfg.Value != "" && cfg.ComplexValue != nil {
+			return nil, fmt.Errorf("Cfg.Name[%s]: Cfg.Value and Cfg.ComplexValue are both non-empty", cfg.Name)
+		}
 		if cfg.ComplexValue != nil {
 			cfgOut[cogName] = cfg.ComplexValue
 		} else {

--- a/generate.go
+++ b/generate.go
@@ -16,12 +16,12 @@ var EnvSubst bool = false
 
 // Cfg holds all the data needed to generate one string key value pair
 type Cfg struct {
-	Name         string      // Defaults to key name unless explicitly declared
-	Value        string      // Cfg.ComplexValue should be nil when Cfg.Value is not an empty string("")
+	Name         string      // defaults to key name in cog file unless var.name="other_name" is used
+	Value        string      // Cfg.ComplexValue should be nil if Cfg.Value is a non-empty string("")
 	ComplexValue interface{} // Cfg.Value should be empty string("") if Cfg.ComplexValue is non-nil
 	Path         string      // filepath string where Cfg can be resolved
 	SubPath      string      // object traversal string used to resolve Cfg if not at top level of document (yq syntax)
-	encrypted    bool        // indicates if value requires decryption
+	encrypted    bool        // indicates if decryption is needed to resolve Cfg.Value
 	readType     readType
 }
 

--- a/generate.go
+++ b/generate.go
@@ -103,22 +103,24 @@ func (g *Gear) ResolveMap(env RawEnv) (map[string]string, error) {
 		}
 	}
 
-	for path, pathGroup := range pathGroups {
+	for p, pGroup := range pathGroups {
 		// 2. for each distinct Path: generate a Reader object
-		cfgFilePath := g.getCfgFilePath(path)
-		fileBuf, err := pathGroup.loadFile(cfgFilePath)
+		cfgFilePath := g.getCfgFilePath(p)
+		fileBuf, err := pGroup.loadFile(cfgFilePath)
 		if err != nil {
 			return nil, err
 		}
 
 		// 3. create yaml visitor to handle SubPath strings
+		if path.Ext(cfgFilePath) == "json" {
+		}
 		visitor, err := NewYamlVisitor(fileBuf)
 		if err != nil {
 			return nil, err
 		}
 
 		// 4. traverse every Path and possible SubPath retrieving the Cfg.Values associated with it
-		for _, cfg := range pathGroup.cfgs {
+		for _, cfg := range pGroup.cfgs {
 			err := visitor.SetValue(cfg)
 			if err != nil {
 				return nil, err
@@ -368,7 +370,7 @@ func parseCfgMap(varName string, baseCfg *Cfg, cfgVal map[string]interface{}) (*
 // 3. path value  is a two index slice with either index possibly holding an empty slice or string value:
 // -  [[], subpath] - path will be inherited from baseCfg if present
 // -  [path, []] - subpath will be inherited from baseCfg if present
-// -  [path, subpath] - nothing will be inherited as both indices hold strings
+// 4. [path, subpath] - nothing will be inherited as both indices hold strings
 func decodePath(v interface{}, cfg *Cfg, baseCfg *Cfg) error {
 	var ok bool
 	var baseCfgSlice []string

--- a/generate_test.go
+++ b/generate_test.go
@@ -18,7 +18,7 @@ type generateTestOut struct {
 	name   string
 	env    string
 	toml   string
-	config map[string]string
+	config map[string]interface{}
 	err    error
 }
 
@@ -28,7 +28,7 @@ func TestGenerate(t *testing.T) {
 			name: "BasicConfig",
 			env:  "local",
 			toml: basicCogToml,
-			config: map[string]string{
+			config: map[string]interface{}{
 				"var":       "var_value",
 				"other_var": "other_var_value",
 			},
@@ -38,7 +38,7 @@ func TestGenerate(t *testing.T) {
 			name: "ConfigWithPath",
 			env:  "qa",
 			toml: basicCogToml,
-			config: map[string]string{
+			config: map[string]interface{}{
 				"enc_var": "|path.enc|./path.enc|subpath|.subpath",
 				"var":     "|path|./path|subpath|.subpath",
 			},
@@ -48,7 +48,7 @@ func TestGenerate(t *testing.T) {
 			name: "ConfigWithInheritedPath",
 			env:  "path_env",
 			toml: basicCogToml,
-			config: map[string]string{
+			config: map[string]interface{}{
 				"var1":     "|path|./path|subpath|.subpath",
 				"var2":     "|path|./path|subpath|.other_subpath",
 				"var3":     "|path|./other_path|subpath|.subpath",
@@ -142,7 +142,7 @@ func (g *testGear) SetName(name string) {
 }
 
 // ResolveMap is used to satisfy the Generator interface
-func (g *testGear) ResolveMap(env RawEnv) (map[string]string, error) {
+func (g *testGear) ResolveMap(env RawEnv) (map[string]interface{}, error) {
 	var err error
 
 	g.cfgMap, err = parseEnv(env)
@@ -151,7 +151,7 @@ func (g *testGear) ResolveMap(env RawEnv) (map[string]string, error) {
 	}
 
 	// final output
-	cfgOut := make(map[string]string)
+	cfgOut := make(map[string]interface{})
 
 	for k, cfg := range g.cfgMap {
 		cfgOut[k] = g.ResolveValue(cfg)

--- a/test_files/json_map.json
+++ b/test_files/json_map.json
@@ -2,7 +2,7 @@
   "var1": "var1_value",
   "var2": "var2_value",
   "var3": "var3_value",
-  "nested_object": {
+  "nested": {
     "var4": "var4_value"
   }
 }

--- a/test_files/json_map.json
+++ b/test_files/json_map.json
@@ -1,8 +1,12 @@
 {
-  "var1": "var1_value",
-  "var2": "var2_value",
-  "var3": "var3_value",
-  "nested": {
-    "var4": "var4_value"
+  "valid_flat_map": {
+    "var1": "var1_value",
+    "var2": "var2_value",
+    "var3": "var3_value"
+  },
+  "var4_complex": {
+    "nested": {
+      "var4": "var4_value"
+    }
   }
 }

--- a/test_files/json_map.json
+++ b/test_files/json_map.json
@@ -1,0 +1,8 @@
+{
+  "var1": "var1_value",
+  "var2": "var2_value",
+  "var3": "var3_value",
+  "nested_object": {
+    "var4": "var4_value"
+  }
+}

--- a/test_files/kustomization.yaml
+++ b/test_files/kustomization.yaml
@@ -4,4 +4,4 @@ configMapGenerator:
       - VAR_1=var1_value
       - VAR_2=var2_value
 jsonMap: |
-  { "VAR_3": "var3_value" }
+  { "VAR_3": "var3_value_demo" }

--- a/test_files/kustomization.yaml
+++ b/test_files/kustomization.yaml
@@ -3,4 +3,5 @@ configMapGenerator:
     literals:
       - VAR_1=var1_value
       - VAR_2=var2_value
-
+jsonMap: |
+  { "VAR_3": "var3_value" }


### PR DESCRIPTION
https://github.com/Bestowinc/cogs/pull/6 should be reviewed and merged first


* Added read type `json{}` to signal complex json file traversal: `var4= {path = [[], "nested"], type = "json{}"}`
* Added read type `whole` [when an entire file's contents](https://github.com/Bestowinc/cogs/blob/6e8d29f7985a31f51e51fe56db369a9f8804946d/advanced.cog.toml#L23) should be bound to a key
* This explicit override attempts to safeguard other config retrieval into being flat k/v pairs
* Added `ComplexValue interface{}` to `Cfg` object