### PR TITLE
TOML pointers in cog definition

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,14 +19,6 @@ jobs:
     strategy:
       matrix:
         out: [json, toml, yaml, dotenv, raw]
-        cog:
-          - "docker basic.cog.toml"
-          - "sops basic.cog.toml"
-          - "kustomize basic.cog.toml"
-          - "inheritor advanced.cog.toml"
-          - "flat_json advanced.cog.toml"
-          - "complex_json advanced.cog.toml"
-          - "envsubst envsubst.cog.toml"
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -38,5 +30,16 @@ jobs:
     - name: Import GPG Key
       run: gpg --import ./test_files/sops_functional_tests_key.asc
     - name: gen docker
-      run: go run ./cmd/cogs ${{ matrix.cog }} --out=${{ matrix.out }}
-    - name: gen ${{ matrix.cog }}
+      run: go run ./cmd/cogs gen docker basic.cog.toml --out=${{ matrix.out }}
+    - name: gen sops
+      run: go run ./cmd/cogs gen sops basic.cog.toml --out=${{ matrix.out }}
+    - name: gen kustomize
+      run: go run ./cmd/cogs gen kustomize basic.cog.toml --out=${{ matrix.out }}
+    - name: gen inheritor
+      run: go run ./cmd/cogs gen inheritor advanced.cog.toml --out=${{ matrix.out }}
+    - name: gen flat_json
+      run: go run ./cmd/cogs gen flat_json advanced.cog.toml --out=${{ matrix.out }}
+    - name: gen complex_json
+      run: go run ./cmd/cogs gen complex_json advanced.cog.toml --out=${{ matrix.out }}
+    - name: gen envsubst
+      run: go run ./cmd/cogs gen envsubst envsubst.cog.toml --out=${{ matrix.out }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,14 @@ jobs:
     strategy:
       matrix:
         out: [json, toml, yaml, dotenv, raw]
+        cog:
+          - "docker basic.cog.toml"
+          - "sops basic.cog.toml"
+          - "kustomize basic.cog.toml"
+          - "inheritor advanced.cog.toml"
+          - "flat_json advanced.cog.toml"
+          - "complex_json advanced.cog.toml"
+          - "envsubst envsubst.cog.toml"
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -30,16 +38,5 @@ jobs:
     - name: Import GPG Key
       run: gpg --import ./test_files/sops_functional_tests_key.asc
     - name: gen docker
-      run: go run ./cmd/cogs gen docker basic.cog.toml --out=${{ matrix.out }}
-    - name: gen sops
-      run: go run ./cmd/cogs gen sops basic.cog.toml --out=${{ matrix.out }}
-    - name: gen kustomize
-      run: go run ./cmd/cogs gen kustomize basic.cog.toml --out=${{ matrix.out }}
-    - name: gen inheritor
-      run: go run ./cmd/cogs gen inheritor advanced.cog.toml --out=${{ matrix.out }}
-    - name: gen flat_json
-      run: go run ./cmd/cogs gen flat_json advanced.cog.toml --out=${{ matrix.out }}
-    - name: gen complex_json
-      run: go run ./cmd/cogs gen complex_json advanced.cog.toml --out=${{ matrix.out }}
-    - name: gen envsubst
-      run: go run ./cmd/cogs gen complex_json envsubst.cog.toml
+      run: go run ./cmd/cogs ${{ matrix.cog }} --out=${{ matrix.out }}
+    - name: gen ${{ matrix.cog }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,8 @@ jobs:
       run: go run ./cmd/cogs gen sops basic.cog.toml --out=${{ matrix.out }}
     - name: gen kustomize
       run: go run ./cmd/cogs gen kustomize basic.cog.toml --out=${{ matrix.out }}
+    - name: gen inheritor
+      run: go run ./cmd/cogs gen inheritor advanced.cog.toml --out=${{ matrix.out }}
     - name: gen flat_json
       run: go run ./cmd/cogs gen flat_json advanced.cog.toml --out=${{ matrix.out }}
     - name: gen complex_json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,3 +41,5 @@ jobs:
       run: go run ./cmd/cogs gen flat_json advanced.cog.toml --out=${{ matrix.out }}
     - name: gen complex_json
       run: go run ./cmd/cogs gen complex_json advanced.cog.toml --out=${{ matrix.out }}
+    - name: gen envsubst
+      run: go run ./cmd/cogs gen complex_json envsubst.cog.toml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With `go`:
 
 Without `go`, `PL`atform can be Linux/Windows/Darwin:
 ```sh
-PL="Darwin" VR="0.4.1" \
+PL="Darwin" VR="0.5.0" \
   curl -SLk \ 
   "github.com/Bestowinc/cogs/releases/download/v${VR}/cogs_${VR}_${PL}_x86_64.tar.gz" | \
   tar xvz -C /usr/local/bin cogs
@@ -17,7 +17,7 @@ PL="Darwin" VR="0.4.1" \
 COGS COnfiguration manaGement S
 
 Usage:
-  cogs gen <ctx> <cog-file> [--out=<type>] [--keys=<key,>] [--not=<key,>] [-n] [-e]
+  cogs gen <ctx> <cog-file> [options]
 
 Options:
   -h --help        Show this screen.
@@ -27,13 +27,17 @@ Options:
   --keys=<key,>    Include specific keys, comma separated.
   --not=<key,>     Exclude specific keys, comma separated.
   --out=<type>     Configuration output type [default: json].
-                   Valid types: json, toml, yaml, dotenv, raw.
+                   <type>: json, toml, yaml, dotenv, raw.
+  
+  --export, -x     If --out=dotenv: Prepends "export " to each line.
+  --preserve, -p   If --out=dotenv: Preserves variable casing.
+  --sep=<sep>      If --out=raw:    Delimits values with a <sep>arator.
 ```
 
 ## annotated spec:
 
 ```toml
-name = "basic_service"
+name = "basic_example"
 
 # key value pairs for a context are defined under <ctx>.vars
 [docker.vars]
@@ -54,11 +58,13 @@ path = ["./test_files/manifest.yaml", "subpath"]
 var1.path = ["./test_files/manifest.yaml", "subpath"]
 var2.path = []
 var3.path = [[], "other_subpath"]
-# dangling variable should return 'some_var = ""' since only name override was defined
-some_var.name = "some_name" 
+# dangling variable should return {"empty_var": ""} since only name override was defined
+empty_var.name = "some_name"
 # key value pairs for an encrypted context are defined under <ctx>.enc.vars
 [sops.enc.vars]
-enc_var.path = "./test_files/test.enc.yaml"
+yaml_enc.path = "./test_files/test.enc.yaml"
+dotenv_enc = {path = "./test_files/test.enc.env", name = "DOTENV_ENC"}
+json_enc.path = "./test_files/test.enc.json"
 
 [kustomize]
 path = ["./test_files/kustomization.yaml", "configMapGenerator.[0].literals"]
@@ -71,6 +77,7 @@ type = "dotenv"
 # be searched for to retrieve the var1 value
 var1 = {path = [], name = "VAR_1"}
 var2 = {path = [], name = "VAR_2"}
+var3 = {path = [[], "jsonMap"], type = "json"}
 ```
 
 ## goals:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,33 @@ DATABASE_SECRETS: "secret_pw"
 
 [TOML spec](https://toml.io/en/v1.0.0-rc.3#keyvalue-pair)
 
-[envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html)
+[envsubst](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) cheatsheet:
+
+
+| __Expression__                   | __Meaning__    |
+| -----------------               | -------------- |
+| `${var}`                        | Value of var (same as `$var`)
+| `${var-${DEFAULT}}`             | If var not set, evaluate expression as ${DEFAULT}
+| `${var:-${DEFAULT}}`            | If var not set or is empty, evaluate expression as ${DEFAULT}
+| `${var=${DEFAULT}}`             | If var not set, evaluate expression as ${DEFAULT}
+| `${var:=${DEFAULT}}`            | If var not set or is empty, evaluate expression as ${DEFAULT}
+| `$$var`                         | Escape expressions. Result will be `$var`.
+| `${var}`                        | Value of var (same as `$var`)
+| `${var^^}`                      | Uppercase value of `$var`
+| `${var,,}`                      | Lowercase value of `$var`
+| `${#var}`                       | Length of `$var`
+| `${var^}`                       |
+| `${var,}`                       |
+| `${var:position}`               |
+| `${var:position:length}`        |
+| `${var#substring}`              |
+| `${var##substring}`             |
+| `${var%substring}`              |
+| `${var%%substring}`             |
+| `${var/substring/replacement}`  |
+| `${var//substring/replacement}` |
+| `${var/#substring/replacement}` |
+| `${var/%substring/replacement}` |
 
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -151,18 +151,17 @@ DATABASE_SECRETS: "secret_pw"
 [envsubst](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) cheatsheet:
 
 
-| __Expression__                   | __Meaning__    |
+| __Expression__                  | __Meaning__    |
 | -----------------               | -------------- |
 | `${var}`                        | Value of var (same as `$var`)
-| `${var-${DEFAULT}}`             | If var not set, evaluate expression as ${DEFAULT}
-| `${var:-${DEFAULT}}`            | If var not set or is empty, evaluate expression as ${DEFAULT}
-| `${var=${DEFAULT}}`             | If var not set, evaluate expression as ${DEFAULT}
-| `${var:=${DEFAULT}}`            | If var not set or is empty, evaluate expression as ${DEFAULT}
+| `${var-`${DEFAULT}`}`           | If var not set, evaluate expression as `${DEFAULT}`
+| `${var:-`${DEFAULT}`}`          | If var not set or is empty, evaluate expression as `${DEFAULT}`
+| `${var=`${DEFAULT}`}`           | If var not set, evaluate expression as `${DEFAULT}`
+| `${var:=`${DEFAULT}`}`          | If var not set or is empty, evaluate expression as `${DEFAULT}`
 | `$$var`                         | Escape expressions. Result will be `$var`.
-| `${var}`                        | Value of var (same as `$var`)
 | `${var^^}`                      | Uppercase value of `$var`
 | `${var,,}`                      | Lowercase value of `$var`
-| `${#var}`                       | Length of `$var`
+| `${#var}`                       | Value of `$var` string length
 | `${var^}`                       |
 | `${var,}`                       |
 | `${var:position}`               |

--- a/advanced.cog.toml
+++ b/advanced.cog.toml
@@ -3,13 +3,25 @@ name = "advanced_example"
 [base.vars]
 var1 = "var1_value"
 var2 = "var2_value"
+json = '''
+{
+  "var3": "var3_value",
+  "some_var": "some_value"
+}
+'''
 
 # inheritor pattern
+# this allows explicit iheritance from base variables without adding more
+# special syntax since the generation path logic does not change
 [inheritor]
-path = ["advanced.cog.toml", "base.vars"]
+# "." - a single period is a reserved filepath string
+# it is used to self-reference the cog file
+# this helps avoid breaking generation when the cog file is moved or renamed
+path = [".", "base.vars"]
 [inheritor.vars]
 var1.path = []
 var2.path = []
+var3 = {path = [[], "base.vars.json"], type ="json"}
 
 # this example mainly deals with how one handles JSON data embedded in another format
 # or as a proper JSON file

--- a/advanced.cog.toml
+++ b/advanced.cog.toml
@@ -11,7 +11,7 @@ json = '''
 '''
 
 # inheritor pattern
-# this allows explicit iheritance from base variables without adding more
+# this allows explicit inheritance from base variables without adding more
 # special syntax since the generation path logic does not change
 [inheritor]
 # "." - a single period is a reserved filepath string

--- a/advanced.cog.toml
+++ b/advanced.cog.toml
@@ -1,4 +1,15 @@
-name = "advanced_service"
+name = "advanced_example"
+
+[base.vars]
+var1 = "var1_value"
+var2 = "var2_value"
+
+# inheritor pattern
+[inheritor]
+path = ["advanced.cog.toml", "base.vars"]
+[inheritor.vars]
+var1.path = []
+var2.path = []
 
 # this example mainly deals with how one handles JSON data embedded in another format
 # or as a proper JSON file

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -1,4 +1,4 @@
-name = "basic_service"
+name = "basic_example"
 
 # key value pairs for a context are defined under <ctx>.vars
 [docker.vars]
@@ -19,11 +19,13 @@ path = ["./test_files/manifest.yaml", "subpath"]
 var1.path = ["./test_files/manifest.yaml", "subpath"]
 var2.path = []
 var3.path = [[], "other_subpath"]
-# dangling variable should return {"some_var": ""} since only name override was defined
-some_var.name = "some_name"
+# dangling variable should return {"empty_var": ""} since only name override was defined
+empty_var.name = "some_name"
 # key value pairs for an encrypted context are defined under <ctx>.enc.vars
 [sops.enc.vars]
-enc_var.path = "./test_files/test.enc.yaml"
+yaml_enc.path = "./test_files/test.enc.yaml"
+dotenv_enc = {path = "./test_files/test.enc.env", name = "DOTENV_ENC"}
+json_enc.path = "./test_files/test.enc.json"
 
 [kustomize]
 path = ["./test_files/kustomization.yaml", "configMapGenerator.[0].literals"]

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -2,6 +2,7 @@ name = "basic_example"
 
 # key value pairs for a context are defined under <ctx>.vars
 [docker.vars]
+web_merge_prefix = "${WEB_MERGE_PREFIX:-${USER^}}_"
 var = "var_value"
 other_var = "other_var_value"
 

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const cmdVersion = "0.6.0"
+const cogsVersion = "0.5.0"
 const usage string = `
 COGS COnfiguration manaGement S
 
@@ -56,7 +56,7 @@ var conf Conf
 
 func main() {
 
-	opts, err := docopt.ParseArgs(usage, os.Args[1:], cmdVersion)
+	opts, err := docopt.ParseArgs(usage, os.Args[1:], cogsVersion)
 	ifErr(err)
 
 	err = opts.Bind(&conf)

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const CogsVersion = "0.6.0"
+const cmdVersion = "0.6.0"
 const usage string = `
 COGS COnfiguration manaGement S
 
@@ -56,7 +56,7 @@ var conf Conf
 
 func main() {
 
-	opts, err := docopt.ParseArgs(usage, os.Args[1:], CogsVersion)
+	opts, err := docopt.ParseArgs(usage, os.Args[1:], cmdVersion)
 	ifErr(err)
 
 	err = opts.Bind(&conf)

--- a/decrypt.go
+++ b/decrypt.go
@@ -7,7 +7,7 @@ import (
 )
 
 func decryptFile(filePath string) ([]byte, error) {
-	sec, err := decrypt.File(filePath, "yaml")
+	sec, err := decrypt.File(filePath, "")
 	if err != nil {
 		return nil, fmt.Errorf("cannot decrypt file: %s", err)
 	}

--- a/e2e.sh
+++ b/e2e.sh
@@ -6,3 +6,5 @@ go run ./cmd/cogs gen kustomize basic.cog.toml
 go run ./cmd/cogs gen inheritor advanced.cog.toml
 go run ./cmd/cogs gen flat_json advanced.cog.toml
 go run ./cmd/cogs gen complex_json advanced.cog.toml
+go run ./cmd/cogs gen inheritor advanced.cog.toml
+go run ./cmd/cogs gen envsubst envsubst.cog.toml -e

--- a/e2e.sh
+++ b/e2e.sh
@@ -3,5 +3,6 @@
 go run ./cmd/cogs gen docker basic.cog.toml
 go run ./cmd/cogs gen sops basic.cog.toml
 go run ./cmd/cogs gen kustomize basic.cog.toml
+go run ./cmd/cogs gen inheritor advanced.cog.toml
 go run ./cmd/cogs gen flat_json advanced.cog.toml
 go run ./cmd/cogs gen complex_json advanced.cog.toml

--- a/envsubst.cog.toml
+++ b/envsubst.cog.toml
@@ -1,0 +1,17 @@
+name = "envsubst_example"
+
+# key value pairs for a context are defined under <ctx>.vars
+[envsubst.vars]
+lowercase_all = "${HOME,,}"
+uppercase_all = "${HOME^^}"
+# # and ## work from the left end (beginning) of string,
+lstrip_greedy = "${HOME}"
+lstrip_nongreedy = "${HOME##/}"
+lstrip_wildcard_greedy = "${HOME#/*/}"
+lstrip_wildcard_nongreedy = "${HOME##/*/}"
+# % and %% work from the right end.
+rstrip_greedy = "${HOME}"
+rstrip_nongreedy = "${HOME%%/}"
+rstrip_wildcard_greedy = "${HOME%/*/}"
+rstrip_wildcard_nongreedy = "${HOME%%/*/}"
+length = "${#HOME}"

--- a/generate.go
+++ b/generate.go
@@ -108,11 +108,18 @@ func (g *Gear) ResolveMap(env RawEnv) (map[string]interface{}, error) {
 			return nil, err
 		}
 
-		newVisitor := NewYamlVisitor
+		newVisitor := NewYAMLVisitor
 		// 3. create visitor to handle SubPath strings
 		// all read files should resolve to a yaml.Node, this includes JSON, TOML, and dotenv
-		if FormatForPath(cfgFilePath) == JSON {
+		switch FormatForPath(cfgFilePath) {
+		case JSON:
 			newVisitor = NewJSONVisitor
+		case YAML:
+			newVisitor = NewYAMLVisitor
+		case TOML:
+			newVisitor = NewTOMLVisitor
+		case Dotenv:
+			newVisitor = NewDotenvVisitor
 		}
 		visitor, err := newVisitor(fileBuf)
 		if err != nil {

--- a/generate.go
+++ b/generate.go
@@ -150,6 +150,9 @@ func (g *Gear) ResolveMap(env RawEnv) (map[string]interface{}, error) {
 }
 
 func (g *Gear) getCfgFilePath(cfgPath string) string {
+	if cfgPath == "." {
+		return g.filePath
+	}
 	if path.IsAbs(cfgPath) {
 		return cfgPath
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.15
 require (
 	cloud.google.com/go v0.72.0 // indirect
 	github.com/Azure/azure-sdk-for-go v48.2.0+incompatible // indirect
-	github.com/Azure/go-autorest/autorest v0.11.11 // indirect
+	github.com/Azure/go-autorest/autorest v0.11.12 // indirect
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.3 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect
-	github.com/aws/aws-sdk-go v1.35.29 // indirect
+	github.com/aws/aws-sdk-go v1.35.33 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/drone/envsubst v1.0.2
@@ -24,24 +24,24 @@ require (
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/lib/pq v1.8.0 // indirect
-	github.com/mikefarah/yq/v3 v3.0.0-20201020025845-ccb718cd0f59
+	github.com/mikefarah/yq/v3 v3.0.0-20201120030024-62f262147cd5
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/mozilla-services/yaml v0.0.0-20201007153854-c369669a6625 // indirect
 	github.com/pelletier/go-toml v1.8.1
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	go.mozilla.org/sops/v3 v3.6.1
 	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 // indirect
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58 // indirect
-	golang.org/x/sys v0.0.0-20201116194326-cc9327a14d48 // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20201117123952-62d171c70ae1 // indirect
+	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go v1.35.33 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
-	github.com/drone/envsubst v1.0.2
+	github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603
 	github.com/frankban/quicktest v1.11.1 // indirect
 	github.com/goccy/go-yaml v1.8.4 // indirect
 	github.com/golang/snappy v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/drone/envsubst v1.0.2 h1:dpYLMAspQHW0a8dZpLRKe9jCNvIGZPhCPrycZzIHdqo=
 github.com/drone/envsubst v1.0.2/go.mod h1:bkZbnc/2vh1M12Ecn7EYScpI4YGYU0etwLJICOWi8Z0=
+github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603 h1:PMzPM0wCHDrXlO7TlEq5lqlhGKHEgSnUR4YMSEVKrQ0=
+github.com/drone/envsubst v1.0.3-0.20200804185402-58bc65f69603/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/Azure/go-autorest/autorest v0.1.0/go.mod h1:AKyIcETwSUFxIcs/Wnq/C+kwC
 github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.11.9/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
-github.com/Azure/go-autorest/autorest v0.11.11 h1:k/wzH9pA3hrtFNsEhJ5SqPEs75W3bzS8VOYA/fJ0j1k=
-github.com/Azure/go-autorest/autorest v0.11.11/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
+github.com/Azure/go-autorest/autorest v0.11.12 h1:gI8ytXbxMfI+IVbI9mP2JGCTXIuhHLgRlvQ9X4PsnHE=
+github.com/Azure/go-autorest/autorest v0.11.12/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
 github.com/Azure/go-autorest/autorest/adal v0.1.0/go.mod h1:MeS4XhScH55IST095THyTxElntu7WqB7pNbZo8Q5G3E=
 github.com/Azure/go-autorest/autorest/adal v0.5.0 h1:q2gDruN08/guU9vAjuPWff0+QIrpH6ediguzdAzXAUU=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
@@ -107,8 +107,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.33.18 h1:Ccy1SV2SsgJU3rfrD+SOhQ0jvuzfrFuja/oKI86ruPw=
 github.com/aws/aws-sdk-go v1.33.18/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/aws/aws-sdk-go v1.35.29 h1:1kYnwrWTp2e+lI9yYFaDo7OFaLug8yXC6Qdj+u8451Q=
-github.com/aws/aws-sdk-go v1.35.29/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/aws/aws-sdk-go v1.35.33 h1:8qPRZqCRok5i7VNN51k/Ky7CuyoXMdSs4mUfKyCqvPw=
+github.com/aws/aws-sdk-go v1.35.33/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -369,8 +369,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mikefarah/yq/v3 v3.0.0-20201020025845-ccb718cd0f59 h1:6nvF+EEFIVD4KT64CgvAzWaMVC283Huno59khWs9r1A=
-github.com/mikefarah/yq/v3 v3.0.0-20201020025845-ccb718cd0f59/go.mod h1:7eVjFf5bgozMuHk+oKpyxR2zCN3iEN1tF0/bM5jvtKo=
+github.com/mikefarah/yq/v3 v3.0.0-20201120030024-62f262147cd5 h1:puqUV8wpOuTvpOu993A2hOkvEe81Y6qqS0HpdDSeIBE=
+github.com/mikefarah/yq/v3 v3.0.0-20201120030024-62f262147cd5/go.mod h1:dYWq+UWoFCDY1TndvFUQuhBbIYmZpjreC8adEAx93zE=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -644,8 +644,8 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201116194326-cc9327a14d48 h1:AYCWBZhgIw6XobZ5CibNJr0Rc4ZofGGKvWa1vcx2IGk=
-golang.org/x/sys v0.0.0-20201116194326-cc9327a14d48/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -782,8 +782,8 @@ google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20201117123952-62d171c70ae1 h1:EVow1AaDgdoMjdO64/fntn4+RGTVor8YE/mkmIYsqFM=
-google.golang.org/genproto v0.0.0-20201117123952-62d171c70ae1/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 h1:Rt0FRalMgdSlXAVJvX4pr65KfqaxHXSLkSJRD9pw6g0=
+google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/input.go
+++ b/input.go
@@ -9,6 +9,8 @@ import (
 	"github.com/drone/envsubst"
 	"github.com/joho/godotenv"
 	"github.com/mikefarah/yq/v3/pkg/yqlib"
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -121,10 +123,40 @@ func NewJSONVisitor(buf []byte) (Visitor, error) {
 }
 
 // NewYamlVisitor returns a visitor object that satisfies the Visitor interface
-func NewYamlVisitor(buf []byte) (Visitor, error) {
+func NewYAMLVisitor(buf []byte) (Visitor, error) {
 	// deserialize to yaml.Node
 	rootNode := &yaml.Node{}
 	if err := yaml.Unmarshal(buf, rootNode); err != nil {
+		return nil, err
+	}
+	return newVisitor(rootNode), nil
+}
+
+// NewTOMLVisitor returns a visitor object that satisfies the Visitor interface
+// attempting to turn a supposed TOML byte slice into a *yaml.Node object
+func NewTOMLVisitor(buf []byte) (Visitor, error) {
+	tempMap := make(map[string]interface{})
+	if err := toml.Unmarshal(buf, &tempMap); err != nil {
+		return nil, errors.Wrap(err, "NewTOMLVisitor")
+	}
+	// deserialize to yaml.Node
+	rootNode := &yaml.Node{}
+	if err := rootNode.Encode(tempMap); err != nil {
+		return nil, err
+	}
+	return newVisitor(rootNode), nil
+}
+
+// NewDotenvVisitor returns a visitor object that satisfies the Visitor interface
+// attempting to turn a supposed dotenv byte slice into a *yaml.Node object
+func NewDotenvVisitor(buf []byte) (Visitor, error) {
+	tempMap, err := godotenv.Unmarshal(string(buf))
+	if err != nil {
+		return nil, err
+	}
+	// deserialize to yaml.Node
+	rootNode := &yaml.Node{}
+	if err := rootNode.Encode(tempMap); err != nil {
 		return nil, err
 	}
 	return newVisitor(rootNode), nil
@@ -166,7 +198,7 @@ func (vi *visitor) SetValue(cfg *Cfg) (err error) {
 		return err
 	}
 
-	if node.Kind != yaml.MappingNode && cfg.readType.Validate() != nil {
+	if node.Kind != yaml.MappingNode && node.Kind != yaml.ScalarNode && cfg.readType.Validate() != nil {
 		return fmt.Errorf("%s: NodeKind/readType unsupported: %s/%s",
 			cfg.Name, kindStr[node.Kind], cfg.readType)
 	}

--- a/input.go
+++ b/input.go
@@ -122,7 +122,7 @@ func NewJSONVisitor(buf []byte) (Visitor, error) {
 	return newVisitor(rootNode), nil
 }
 
-// NewYamlVisitor returns a visitor object that satisfies the Visitor interface
+// NewYAMLVisitor returns a visitor object that satisfies the Visitor interface
 func NewYAMLVisitor(buf []byte) (Visitor, error) {
 	// deserialize to yaml.Node
 	rootNode := &yaml.Node{}

--- a/input.go
+++ b/input.go
@@ -85,7 +85,21 @@ func envSubFile(filePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	substEnv, err := envsubst.EvalEnv(string(bytes))
+
+	// ------------------------------------------------------------------------
+	// strip comments so we dont do comment substitution by tokenizing the file
+	// and reemiting the file as bytes  ¯\_(ツ)_/¯
+	tree, err := toml.LoadBytes(bytes)
+	if err != nil {
+		return "", err
+	}
+	noCommentTree, err := toml.Marshal(tree)
+	if err != nil {
+		return "", err
+	}
+	// ------------------------------------------------------------------------
+
+	substEnv, err := envsubst.EvalEnv(string(noCommentTree))
 	if err != nil {
 		return "", err
 	}

--- a/output.go
+++ b/output.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/pelletier/go-toml"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Format represents the final marshalled k/v output type from a resolved Gear
@@ -116,3 +116,5 @@ func FormatForCfg(cfg *Cfg) (format Format) {
 	}
 	return format
 }
+
+// getForatm

--- a/output.go
+++ b/output.go
@@ -116,5 +116,3 @@ func FormatForCfg(cfg *Cfg) (format Format) {
 	}
 	return format
 }
-
-// getForatm

--- a/test_files/test.enc.env
+++ b/test_files/test.enc.env
@@ -1,0 +1,14 @@
+DOTENV_ENC=ENC[AES256_GCM,data:wTW7px/rP11KFA==,iv:g/gaga+6BCQ57kfNT9Dyxp6yHGpdceSHfog7CioLVRM=,tag:ojvSFpUHl2BqHgYRr9RSGA==,type:str]
+sops_pgp__list_1__map_created_at=2020-11-21T20:18:33Z
+sops_pgp__list_0__map_enc=-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQf/fHzZ2FeIG30SQNm5RVkE/xWOlMnLrEHhB/X65DgbYExV\nw3EWganBKB/tvogjV+9FxyFwLhOTsHzNacIGju0UbIONlF6fouPaEx0ttf1Xi/No\nWL8TBNr4yQH4ho/JuP/wjk3i4rOFAeeJoJdadb3OL6iAVOc7EnZ5U6jOFaMtnRn4\n2hzToUacpTyEDYkDESUlIxLnV5haxiIN+UolAbT6gT81abn7Yel9A7QgxKxv4KD6\nzfH9DHiBas87FMraLv01aEt/xJYk56AFPmNYHmmCkZwgWmQwtFlKxQLxm7Wv1XVU\nIHbuij8Wa5esMbv5YVzaNABIv5VD5KvQgQKjATgYr9JeAViqaziCol5jMDP/YQs9\nfEg1Mz7WYneBCH0Hz1oiCxirSGh33C/bgcdESGu71Q1wSlg7w1l1OZFdkwQmEPvy\n92PAEPYG7MZX98MjCp4XBGsd6cbTDmIdFxHXtagYLA==\n=xB/t\n-----END PGP MESSAGE-----\n
+sops_lastmodified=2020-11-21T21:26:14Z
+sops_pgp__list_0__map_created_at=2020-11-21T20:18:33Z
+sops_pgp__list_1__map_enc=-----BEGIN PGP MESSAGE-----\n\nhIwDXFUltYFwV4MBA/0Ux08wY1uvTWq/9u1z39zjy5cw5CPnJ0xsxZZsJSOS5QCa\nJbSkTUXcV1wrEdd/tr93eFzYtVE7UZDNCmscbG7r62RENGoYRPA3sPEMDMn88eGt\nQOQGDEc8Ve5X5nCJSDzN757YKV+XewSULHyepwPt52Bapqd+FX1/zL42va7cSdJe\nAeDu/zH+xx/JHMwX6tQ9oUcTh/tgDdWl/OOKUqsgHmmGtPVplXFBgDLZ7oIGHAO2\nc/b+XXWJja3ALOw9qYeRrBBq37EonM0fUx7DIBthOmjU9sf0wEeLILmTWOayZg==\n=z0OJ\n-----END PGP MESSAGE-----\n
+sops_pgp__list_2__map_enc=-----BEGIN PGP MESSAGE-----\n\nhQEMA4MtkfS+oCVpAQgAsBJtmX3SQYkE8su2hW/Pgud4/h2GTeBY9L/GBfjYrQHk\neoVg+xdvN+yyv5V02fdL/F4MvHq7E8c2QElwHBr1Zf/ZkrW5bTs50uahiiQbk73I\nwcip8Bhtkl49gp4Zs1uHR2ecs58zPCNoOKEAFO8IxdOMJ8/bmc6lYS3If8HL06+j\ngoEGtteZ6Fhy0GEfAxT1wR3Qb9Ony64bxPvMnNaTpwZOKCNOT5t18XjUXQ5GbV5S\naUXV9OwdDxrt2bZ2DnfVlkap+TsOUF2vzn5IWj3I/OT0jKa8iiObUjdEXn1WpCqS\nWaIiByw2Qi0Ma7VRVQRYwmSfA9hZGQlsXURNwyq3W9JeAes+WgtFz8rjmuK2vX8z\nAHN9IJNjP/vRdLRo+b/91Yo6ni4uX8EOn/xuXVbTWCjrrEQPRgbos88sRkjOpDu4\nzZDj0Z4xqqPIXOARs5h9uK8YcJIFqfe8lZglfgvAew==\n=FPbP\n-----END PGP MESSAGE-----\n
+sops_version=3.6.1
+sops_pgp__list_0__map_fp=FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+sops_pgp__list_2__map_created_at=2020-11-21T20:18:33Z
+sops_pgp__list_2__map_fp=B611A2F9F11D0FF82568805119F9B5DAEA91FF86
+sops_mac=ENC[AES256_GCM,data:g9p7GZSsl8SlXXZ6pKY8suG02vCzkD2GnwMv+JQHwWHFjfJZggC/SGiw5DEuFfUKssSXpKgj3kDcvuM8jG8Q6zNXY9AAtkAoXfv3BBpR9TSuuQNKPdLZeFARWgSK5It3WO3upITdnZIgZdGSJrkRXG8EiPkW5M/KQmwmx7r9dgo=,iv:jdovU2X/2MeoZRW+NBOVGQP8VC9sLD7Yr2RRaaHoWHs=,tag:8OQAfE/xy9uE16P/Siu6Ag==,type:str]
+sops_pgp__list_1__map_fp=D7229043384BCC60326C6FB9D8720D957C3D3074
+sops_unencrypted_suffix=_unencrypted

--- a/test_files/test.enc.json
+++ b/test_files/test.enc.json
@@ -1,0 +1,30 @@
+{
+	"json_enc": "ENC[AES256_GCM,data:ni9gPnMi45E=,iv:XWujxK0NMXd/Hc4sesosl3AWAGv0bpxFlPT1Xg8iFNk=,tag:8vuRQnpD7E8qgyJJMus/HQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-11-21T21:28:24Z",
+		"mac": "ENC[AES256_GCM,data:kX8b70bCegSoFSoUo0n6K1EI3Z83SyoSOUaKdqT1TV1+M2nQO27NJTmiybKPXzl4i20d5XAjWPnuordSAgLuRJWrH8JYFDCLcM3lgXquVjYajLRp7wdVDYBzHxlz/XCW0Rv5fu9F1yY08rEULNhtRPLIJK8m/cNGWxEo2wQi3Vw=,iv:YF6d/jONjXPwWjDFfOSw/Krri2bPortaTsw4TYOY0V8=,tag:DGmUb9Hc9cLkPlhQKEADpg==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-11-21T21:28:23Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQgAqv0JhnILRyo69CrmBVxh2g35a/O7u2LVTZ1zNGbyMxOe\nbqT4Fz+Ol4nppiCic0rTXqVmAcbKUfGc6+f+AELv4gljVJPnsgvETNAPn/kF3Z0k\njIHKFkId/HDPvhEjC84gFYp6DJotXBqGBfVNMLwxCHo3cPH+JPSpi4ynnh3cHjVI\nJ59VMXy/3lMSRrcZH6rYDasobXLGWjB0+M5qElJnTjspTYWHpwcUBF4hwON9aQEu\n1D8mzMjrrzC6sd1Vwn4/LWKx2C25cqT+vrFMt5a78QbY8EIPAR6lwcDzapMs9T3k\ncNdbmHrnz4VwXIdyW+NkQ7u0Tg9IfKUVAF1j4MJ/xNJcAWry5gz1RucII/Wscyjo\nt7U+kuEZcuxWBrdohKpcAURA/umCrYGqK4m2MOUWole5GmOLYXd4i45GqHQwFJia\nR6S4gtuyRmTAlc8ST56/EvzEGVLMoaqmqeF0LkY=\n=Y42B\n-----END PGP MESSAGE-----\n",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			},
+			{
+				"created_at": "2020-11-21T21:28:23Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwYwDXFUltYFwV4MBBABe+8KKZF9oRngsuCn/15i+dSKHiDK4Z8TXMwdKNqRbAk0m\nV1r75M5BvgupiocyflQ9L5NzLgoxez3KiKUEUSMixTXOFU25qeucvLuznnw9e/BR\nda/H3fYSGQNzRsH9HQYB66iXNvZ6QRohF25YnunfMCYJMcP0sUCYfFi+7Uifn9Lm\nAaOVU2l44hBlmnxbequvDfywUH0lEJxvoQkC93AztFeDr9gIy7bNz8uvyPgeTvvZ\njg8dH971AmuHlXb7hS0wauTqY0+BUmzFDAX5sUkv0GLk4kFySRUA\n=DP/P\n-----END PGP MESSAGE-----",
+				"fp": "D7229043384BCC60326C6FB9D8720D957C3D3074"
+			},
+			{
+				"created_at": "2020-11-21T21:28:23Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQEMA4MtkfS+oCVpAQf/eh/lW7CCwGUl8j3UWncAoE+hY8U8zp1tKnL5YFPGjxu5\nppkLnic62IkpSmCVTIQHlm9h3tLsnK3ZR/CLgvL3c0Ub1FNSV9cEpIEzLZqvoo4w\nozaOmUalQmACsnS8sNzDCNUElrJZtxqwZpseTRLosdkb2ntQacBDW6WuPCaQsdnP\nZNmM0fvm18f2d56h7jlZ0zV9DsFybZv3Fb6LUvLRrbVWrtYfY3JTHhjp1bAtybee\nWn6aC/fjxoNUGIyXbPWhYAzB1m9XdBwGLC9YdhSbejonPvxfSFya9ejIcJB0yR9/\nu04oEC+cgUaCiOvvSW7Trc6X00Z+soRxsbaM4zlGZtJcAVIUerNc69k89Yw8Yup7\nq6pxAr6I9OzU43Jm0VbuH9aIcs4ifmIDfyJDeQWxXLmX6byTbF8cdEB/308HWCUR\niBDX/ZtbhruXolwHPoIVJdN4wSsb+LjBR/OFnrQ=\n=khmE\n-----END PGP MESSAGE-----\n",
+				"fp": "B611A2F9F11D0FF82568805119F9B5DAEA91FF86"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/test_files/test.enc.yaml
+++ b/test_files/test.enc.yaml
@@ -1,11 +1,12 @@
-enc_var: ENC[AES256_GCM,data:mhOPkzux8QHlvt1lenPK,iv:I/kYPukhj79I6y5PH6fdFKPOtwHTukkosbPxE15sIX4=,tag:dzAhCfRu3bf/bv+6gFJ/Uw==,type:str]
+yaml_enc: ENC[AES256_GCM,data:Ukyf4txCgpb705IRdF8b,iv:bky7WHSgswxgnQWDfRuRsGDiztG25JeL/lwYgTXoaU0=,tag:TECYoBdAZQLVil9paJhjtA==,type:str]
 other_var: ENC[AES256_GCM,data:6Aom3EdUq9bv2XZXpeUKRfCYA7ua,iv:byCZsK5nvw5ixecFaAzCwbBbyS4KmwpfMhjveuSyNfs=,tag:pzZWgQYs4EPttNVChVp/ag==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-10-15T15:47:20Z'
-    mac: ENC[AES256_GCM,data:MRoZRUlTpWYuGzcxx4BctTtxjHvEXxGb3cT9jCTvkZrGiUn9hiisl6ldc90/A3WSKccUqOPsflmK4XIrNZrXrNfmbONh/854jh1Ry+onRmT6JhSdaZnLLYHt7FhljTApRVs0n8yKvERo66HK5MMjn8V8onXAGO0bB3Tqp+8NegA=,iv:HOo9E32aIwBRjqIxugVakuJAfb5lct21dPspl5xEWw4=,tag:u0hmJGsTMfXweDt8Eu5z2w==,type:str]
+    hc_vault: []
+    lastmodified: '2020-11-21T21:25:35Z'
+    mac: ENC[AES256_GCM,data:+q4M25FUfz7HmFnJuCKSq8ApszEeu9lC4Q5wwJFSgA4t8Cns18VDodrzcW1CgyQ5vkP2xfQtsnnzQkGOW+hZG/F2O+xoQBiPnH1rMyVtLrS/hxt+LM217GzScKJJ3fvN75eEKF/9lIWuipl4UKuNRyJdyiAI3WVmrfIEVssczv4=,iv:qlc/JEEg5kcTVlPFCrtIKrWMQXC4gyama64I3hEkTT0=,tag:kIC9f4mq9VWTXb8TCwwhYg==,type:str]
     pgp:
     -   created_at: '2020-10-13T19:04:54Z'
         enc: |
@@ -35,4 +36,4 @@ sops:
             -----END PGP MESSAGE-----
         fp: D7229043384BCC60326C6FB9D8720D957C3D3074
     unencrypted_suffix: _unencrypted
-    version: 3.5.0
+    version: 3.6.1


### PR DESCRIPTION
 * Added e2e tests for encrypted dotenv and json files
* cog paths can now reference TOML files, this includes the cog file itself
* added `"."` reserved string value for filepath pointers:  
   https://github.com/Bestowinc/cogs/blob/6b0637f2d96634881703ded7bf316c711fca4eb7/advanced.cog.toml#L17-L20
