### PR TITLE
added strconv logic to output.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With `go`:
 
 Without `go`, `PL`atform can be Linux/Windows/Darwin:
 ```sh
-PL="Darwin" VR="0.7.1" \
+PL="Darwin" VR="0.7.2" \
   curl -SLk \ 
   "github.com/Bestowinc/cogs/releases/download/v${VR}/cogs_${VR}_${PL}_x86_64.tar.gz" | \
   tar xvz -C /usr/local/bin cogs

--- a/advanced.cog.toml
+++ b/advanced.cog.toml
@@ -36,16 +36,18 @@ var4 = {path = [], type ="toml{}"}
 # the base object is simply found in an external file
 [external_inheritor]
 path = ["test_files/external_inheritor.json", ".base"]
-# since base.json is not a flat string to string map
-# type must be set to JSONcomplex akak "json{}" instead of the inherited json type
-type = "json"
 [external_inheritor.vars]
 var1.path = []
 var2.path = []
+
+# read type must be explicit since we are dealing with a JSON string *inside* of a JSON object
+var3.type = "json"
 var3.path = [[], ".base.json_string"]
-# read type must be explicit since we are dealing with a JSON string inside of a JSON object
-var3.type = "json" 
-var4 = {path = [], type = "json{}"}
+
+# since `var4` does not map to a flat string
+# type must be set to JSONcomplex aka "json{}" instead of the inherited json type
+var4.type = "json{}"
+var4.path = []
 
 # this example mainly deals with how one handles JSON data embedded in another format
 # or as a proper JSON file

--- a/basic.cog.toml
+++ b/basic.cog.toml
@@ -5,6 +5,10 @@ name = "basic_example"
 var = "var_value"
 other_var = "other_var_value"
 
+# dangling variable names should return an error
+# try uncommenting the line below and run `cogs gen docker basic.cog.toml`
+# empty_var.name = "some_name"
+
 [sops]
 # a default path to be inherited can be defined under <ctx>.path
 path = ["./test_files/manifest.yaml", ".subpath"]
@@ -19,8 +23,8 @@ path = ["./test_files/manifest.yaml", ".subpath"]
 var1.path = ["./test_files/manifest.yaml", ".subpath"]
 var2.path = []
 var3.path = [[], ".other_subpath"]
-# dangling variable should return {"empty_var": ""} since only name override was defined
-empty_var.name = "some_name"
+
+
 # key value pairs for an encrypted context are defined under <ctx>.enc.vars
 [sops.enc.vars]
 yaml_enc.path = "./test_files/test.enc.yaml"

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const cogsVersion = "0.7.1"
+const cogsVersion = "0.7.2"
 const usage string = `
 COGS COnfiguration manaGement S
 

--- a/generate.go
+++ b/generate.go
@@ -297,6 +297,7 @@ func parseCtx(ctx baseContext) (linkMap LinkMap, err error) {
 type baseContext struct {
 	Path     interface{} `mapstructure:",omitempty"`
 	ReadType string      `mapstructure:"type,omitempty"`
+	Name     string      `mapstructure:",omitempty"`
 	Vars     CfgMap      `mapstructure:",omitempty"`
 	Enc      context     `mapstructure:",omitempty"`
 }
@@ -305,6 +306,7 @@ func (b baseContext) toContext() context {
 	return context{
 		Path:     b.Path,
 		ReadType: b.ReadType,
+		Name:     b.Name,
 		Vars:     b.Vars,
 	}
 }
@@ -312,6 +314,7 @@ func (b baseContext) toContext() context {
 type context struct {
 	Path     interface{} `mapstructure:",omitempty"`
 	ReadType string      `mapstructure:"type,omitempty"`
+	Name     string      `mapstructure:",omitempty"`
 	Vars     CfgMap      `mapstructure:",omitempty"`
 }
 
@@ -325,7 +328,8 @@ func decodeVars(linkMap LinkMap, ctx context) error {
 			return err
 		}
 	}
-
+	// global search name
+	baseLink.SearchName = ctx.Name
 	// global type
 	baseLink.readType = readType(ctx.ReadType)
 	if err := baseLink.readType.Validate(); err != nil {
@@ -338,8 +342,8 @@ func decodeVars(linkMap LinkMap, ctx context) error {
 			return fmt.Errorf("%s: duplicate key present in ctx and ctx.enc", k)
 		} else if IsSimpleValue(v) {
 			linkMap[k] = &Link{
-				SearchName: k,
-				Value:      v,
+				KeyName: k,
+				Value:   v,
 			}
 		} else if cfgMap, ok := v.(map[string]interface{}); ok {
 			if linkMap[k], err = parseLinkMap(k, &baseLink, cfgMap); err != nil {
@@ -393,7 +397,6 @@ func parseLinkMap(varName string, baseLink *Link, cfgMap CfgMap) (*Link, error) 
 				return nil, fmt.Errorf("%s.type: %w", varName, err)
 			}
 		case "gear_keys":
-			panic("rGear unsupported at this time")
 			keysErr := fmt.Errorf("%s.keys must be a string or array of strings", varName)
 			link.keys = []string{}
 			slice, ok := v.([]interface{})
@@ -408,6 +411,7 @@ func parseLinkMap(varName string, baseLink *Link, cfgMap CfgMap) (*Link, error) 
 				link.keys = append(link.keys, str)
 
 			}
+			panic("rGear unsupported at this time")
 		case "header": // "net/http".Header is of type Header map[string][]string
 			link.header = make(http.Header)
 			headerErr := fmt.Errorf("%s.header must map to a string or array of strings", varName)
@@ -435,6 +439,12 @@ func parseLinkMap(varName string, baseLink *Link, cfgMap CfgMap) (*Link, error) 
 		}
 
 	}
+
+	// if Path is empty string
+	if link.Path == "" {
+		return nil, fmt.Errorf("%s does not have a value assigned or %s.path defined", varName, varName)
+	}
+
 	// if readType was not specified:
 	if _, ok := cfgMap["type"]; !ok {
 		if baseLink != nil {
@@ -448,6 +458,10 @@ func parseLinkMap(varName string, baseLink *Link, cfgMap CfgMap) (*Link, error) 
 	link.KeyName = varName
 	if _, ok := cfgMap["name"]; !ok {
 		link.SearchName = varName
+		// if ctx.name was set then and var.name was not defined then inherit SearchName from baseLink
+		if baseLink.SearchName != "" {
+			link.SearchName = baseLink.SearchName
+		}
 	}
 
 	return &link, nil

--- a/generate.go
+++ b/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 )
 
@@ -254,7 +255,12 @@ func generate(ctxName string, tree *toml.Tree, gear Resolver) (CfgMap, error) {
 
 	ctxTree, ok := tree.Get(ctxName).(*toml.Tree)
 	if !ok {
-		return nil, fmt.Errorf("%s context missing from cog file", ctxName)
+		// TODO  ErrMissingContext = errorW{fmt:"%s: %s context missing from cog file"}
+		errMsg := fmt.Sprintf("%s context missing from cog file", ctxName)
+		if g, ok := gear.(*Gear); ok {
+			errMsg = g.filePath + ": " + errMsg
+		}
+		return nil, errors.New(errMsg)
 	}
 
 	var ctxMap map[string]interface{}


### PR DESCRIPTION

* implemented simple type stringing logic:`int64` types were returning `%!s(int64=5054)%` when being called from `Sprintf("%s", t)`, that's no longer the case
* `ctx.name` is now an inheritable global property