### PR TITLE
fix parsing yaml with dash in keys

### DIFF
--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Bestowinc/cogs"
 )
 
-const cogsVersion = "0.10.1"
+const cogsVersion = "0.10.2"
 const usage string = `
 COGS COnfiguration manaGement S
 

--- a/examples/4.read_types.cog.toml
+++ b/examples/4.read_types.cog.toml
@@ -17,3 +17,4 @@ type = "dotenv"
 var1 = {path = [], name = "VAR_1"}
 var2 = {path = [], name = "VAR_2"}
 var3 = {path = [[], ".jsonMap"], type = "json"}
+var4 = {path = [], name = "KEY-WITH_DASH"}

--- a/input.go
+++ b/input.go
@@ -336,8 +336,17 @@ func visitDotenv(cache map[string]interface{}, node *yaml.Node) (err error) {
 					originalKey := parts[0]
 					if strings.Contains(originalKey, "-") {
 						sanitizedKey := strings.ReplaceAll(originalKey, "-", "_")
-						keyMapping[sanitizedKey] = originalKey
-						sliceEnv[x] = sanitizedKey + "=" + parts[1]
+						uniqueKey := sanitizedKey
+						counter := 1
+						for {
+							if _, exists := keyMapping[uniqueKey]; !exists {
+								break
+							}
+							uniqueKey = fmt.Sprintf("%s_%d", sanitizedKey, counter)
+							counter++
+						}
+						keyMapping[uniqueKey] = originalKey
+						sliceEnv[x] = uniqueKey + "=" + parts[1]
 					}
 				}
 			}

--- a/input.go
+++ b/input.go
@@ -314,6 +314,9 @@ func (vi *visitor) get(subPath string) (*yaml.Node, error) {
 func visitDotenv(cache map[string]interface{}, node *yaml.Node) (err error) {
 	var strEnv string
 
+	// Handle dashes in variable names by creating a mapping
+	keyMapping := make(map[string]string)
+
 	if err = node.Decode(&strEnv); err != nil {
 		var sliceEnv []string
 		if err := node.Decode(&sliceEnv); err != nil {
@@ -325,6 +328,19 @@ func visitDotenv(cache map[string]interface{}, node *yaml.Node) (err error) {
 			if strings.Contains(line, "\n") {
 				sliceEnv[x] = regexp.MustCompile(`(?s)=([^"'].+)`).ReplaceAllString(line, `='$1'`)
 			}
+
+			// Find and replace keys with dashes
+			if strings.Contains(line, "=") {
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) == 2 {
+					originalKey := parts[0]
+					if strings.Contains(originalKey, "-") {
+						sanitizedKey := strings.ReplaceAll(originalKey, "-", "_")
+						keyMapping[sanitizedKey] = originalKey
+						sliceEnv[x] = sanitizedKey + "=" + parts[1]
+					}
+				}
+			}
 		}
 
 		strEnv = strings.Join(sliceEnv, "\n")
@@ -334,8 +350,14 @@ func visitDotenv(cache map[string]interface{}, node *yaml.Node) (err error) {
 	if err != nil {
 		return err
 	}
+
+	// Restore original keys with dashes
 	for k, v := range dotenvMap {
-		cache[k] = v
+		if originalKey, exists := keyMapping[k]; exists {
+			cache[originalKey] = v
+		} else {
+			cache[k] = v
+		}
 	}
 
 	return err

--- a/test_files/kustomization.yaml
+++ b/test_files/kustomization.yaml
@@ -7,6 +7,8 @@ configMapGenerator:
         SOME_MULTILINE_JSON={
          "some_key": "some_value",
         }
+      - VAL_WITH_DASH=some-val
+      - KEY-WITH_DASH=some_val
 jsonMap: { "var3": "var3_value" }
 complexJsonMap: |
   {


### PR DESCRIPTION
This fixes cogs yaml parsing when a yaml variable name has a dash/hyphen.