### PR TITLE
fix: do not return secret if no decrypt for gsm

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Behavior worth knowing:
 * **Failures are reported together.** A batch with several bad secret ids names every one of them, in a stable order, rather than dying on the first.
 * **`.enc` placement is advisory.** A GSM link resolves identically inside or outside an `.enc` block; putting it under `.enc` only signals that the value is sensitive.
 * **`--no-enc`** skips GSM vars under `.enc`, like any other encrypted var.
-* **`--no-decrypt` yields `[encrypted]`.** Unlike SOPS, there is no ciphertext form of a GSM secret to hand back, so an opaque placeholder stands in for the payload. No fetch is made and no credentials are needed, so the flag works with no GCP access at all. This applies to every `gcpsm://` var, inside `.enc` or not, and a var with a `type` gets the placeholder rather than a parsed map — the same way a typed read of an undecrypted SOPS file yields its ciphertext string. Because nothing is fetched, a secret that does not exist is not reported as missing until a real run.
+* **`--no-decrypt` returns `[encrypted]`.** Unlike SOPS, there is no ciphertext form of a GSM secret. Thus, no fetch is done.
 
 ## `envsubst` cheatsheet:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Options:
   -h --help        Show this screen.
   --version        Show version.
   --no-enc, -n     Skips fetching encrypted vars.
-  --no-decrypt	   Skipts decrypting encrypted vars.
+  --no-decrypt	   Skips decrypting encrypted vars.
   --envsubst, -e   Perform environmental substitution on the given cog file.
   --keys=<key,>    Include specific keys, comma separated.
   --not=<key,>     Exclude specific keys, comma separated.
@@ -150,7 +150,7 @@ Behavior worth knowing:
 * **Failures are reported together.** A batch with several bad secret ids names every one of them, in a stable order, rather than dying on the first.
 * **`.enc` placement is advisory.** A GSM link resolves identically inside or outside an `.enc` block; putting it under `.enc` only signals that the value is sensitive.
 * **`--no-enc`** skips GSM vars under `.enc`, like any other encrypted var.
-* **`--no-decrypt` still fetches.** Unlike SOPS, there is no ciphertext form of a GSM secret to hand back.
+* **`--no-decrypt` yields `[encrypted]`.** Unlike SOPS, there is no ciphertext form of a GSM secret to hand back, so an opaque placeholder stands in for the payload. No fetch is made and no credentials are needed, so the flag works with no GCP access at all. This applies to every `gcpsm://` var, inside `.enc` or not, and a var with a `type` gets the placeholder rather than a parsed map — the same way a typed read of an undecrypted SOPS file yields its ciphertext string. Because nothing is fetched, a secret that does not exist is not reported as missing until a real run.
 
 ## `envsubst` cheatsheet:
 

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Bestowinc/cogs"
 )
 
-const cogsVersion = "0.11.0"
+const cogsVersion = "0.11.1"
 const usage string = `
 COGS COnfiguration manaGement S
 

--- a/examples/7.secret_manager.cog.toml
+++ b/examples/7.secret_manager.cog.toml
@@ -44,5 +44,4 @@ other_password = {path = ["gcpsm://other-project", "current"], name = "other-db-
 #   corrupt values such as PGPASSWORD
 # - vars pointing at the same project/secret/version are fetched once
 # - a secret that does not exist is reported as a missing key
-# - --no-decrypt resolves every gcpsm var to "[encrypted]": there is no ciphertext
-#   form of a GSM secret, and nothing is fetched, so no credentials are needed
+# - --no-decrypt resolves every gcpsm var to "[encrypted]"

--- a/examples/7.secret_manager.cog.toml
+++ b/examples/7.secret_manager.cog.toml
@@ -44,4 +44,5 @@ other_password = {path = ["gcpsm://other-project", "current"], name = "other-db-
 #   corrupt values such as PGPASSWORD
 # - vars pointing at the same project/secret/version are fetched once
 # - a secret that does not exist is reported as a missing key
-# - --no-decrypt still fetches: there is no ciphertext form of a GSM secret
+# - --no-decrypt resolves every gcpsm var to "[encrypted]": there is no ciphertext
+#   form of a GSM secret, and nothing is fetched, so no credentials are needed

--- a/generate.go
+++ b/generate.go
@@ -150,6 +150,15 @@ func (g *Gear) ResolveMap(ctx baseContext) (CfgMap, error) {
 			continue
 		}
 
+		// NoDecrypt must not reach the network, so the placeholder is assigned before
+		// a path group is built: no client, no credentials, no fetch. A read type
+		// collapses to the placeholder too, matching SOPS, where a typed read of an
+		// undecrypted file yields the ciphertext string rather than a parsed map
+		if NoDecrypt && isSecretManagerPath(link.Path) {
+			link.Value = EncryptedPlaceholder
+			continue
+		}
+
 		if _, ok := pathGroups[link.distinctPath()]; !ok {
 			// read plaintext file into bytes
 			loadFile := readFile

--- a/secretmanager.go
+++ b/secretmanager.go
@@ -25,6 +25,10 @@ const SecretManagerScheme = "gcpsm://"
 // defaultSecretVersion is used when a GSM link declares no version alias
 const defaultSecretVersion = "latest"
 
+// EncryptedPlaceholder stands in for a GSM payload when NoDecrypt is set: a GSM
+// secret has no local ciphertext form to hand back the way a SOPS value does
+const EncryptedPlaceholder = "[encrypted]"
+
 // SecretManagerConcurrency bounds the number of simultaneous Secret Manager fetches
 var SecretManagerConcurrency int = 8
 

--- a/secretmanager_test.go
+++ b/secretmanager_test.go
@@ -431,10 +431,45 @@ pw = {path = ["gcpsm://proj", "current"], name = "secret"}
 	}
 }
 
-// NoDecrypt has no ciphertext form to hand back for a GSM secret, so the fetch still happens
-func TestSecretManagerIgnoresNoDecrypt(t *testing.T) {
-	stub := &stubFetcher{payloads: map[string]string{"secret": "pw"}}
+// a GSM secret has no ciphertext form, so NoDecrypt hands back a placeholder
+// instead, and never reaches the network to do it
+func TestSecretManagerNoDecryptPlaceholder(t *testing.T) {
+	stub := &stubFetcher{payloads: map[string]string{"secret": "pw", "json": `{"user":"u"}`}}
 	stub.install(t)
+
+	NoDecrypt = true
+	t.Cleanup(func() { NoDecrypt = false })
+
+	_, cfg, err := genGear(t, "qa", `
+name = "sm"
+[qa.vars]
+plain = {path = ["gcpsm://proj", "current"], name = "secret"}
+[qa.enc.vars]
+pw = {path = ["gcpsm://proj", "current"], name = "secret"}
+typed = {path = ["gcpsm://proj", "current"], name = "json", type = "json"}
+`)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	// a gcpsm link is a secret wherever it is declared, .enc or not
+	for _, key := range []string{"plain", "pw", "typed"} {
+		if cfg[key] != EncryptedPlaceholder {
+			t.Errorf("%s = %q, want %q", key, cfg[key], EncryptedPlaceholder)
+		}
+	}
+	if n := stub.callCount(); n != 0 {
+		t.Errorf("fetched %d times, want 0", n)
+	}
+}
+
+// NoDecrypt needs no credentials at all: a fetcher that cannot even be built
+// must not fail the run
+func TestSecretManagerNoDecryptNeedsNoFetcher(t *testing.T) {
+	orig := newSecretFetcher
+	newSecretFetcher = func(gocontext.Context) (secretFetcher, func(), error) {
+		return nil, nil, fmt.Errorf("no credentials")
+	}
+	t.Cleanup(func() { newSecretFetcher = orig })
 
 	NoDecrypt = true
 	t.Cleanup(func() { NoDecrypt = false })
@@ -447,8 +482,8 @@ pw = {path = ["gcpsm://proj", "current"], name = "secret"}
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
-	if cfg["pw"] != "pw" {
-		t.Errorf("pw = %q, want the fetched value", cfg["pw"])
+	if cfg["pw"] != EncryptedPlaceholder {
+		t.Errorf("pw = %q, want %q", cfg["pw"], EncryptedPlaceholder)
 	}
 }
 


### PR DESCRIPTION
If `--no-decrypt` is provided and the secret is resolved from Google Secret Manager, then we should return a default value like `[encrypted]` instead of fetching and returning the secret value. This aligns more closely with the intent of the flag and prevents leaking decrypted secrets. The default value is necessary because secrets from GSM have no unencrypted value.

I validated with the following:

```sh
go build -o cogs ./cmd/cogs
mv cogs ../ryerson/.go/.bin
# in ryerson repo
./go set-env qa --out=dotenv --no-decrypt --envsubst
```

Partial output:

```
CASH_VALUE_RO_DB__NAME="cash-value"
CASH_VALUE_RO_DB__PASSWORD="[encrypted]"
```