### PR TITLE
feat(output): docker compose style env

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,31 @@ Options:
   --keys=<key,>    Include specific keys, comma separated.
   --not=<key,>     Exclude specific keys, comma separated.
   --out=<type>     Configuration output type [default: json].
-                   <type>: json, toml, yaml, dotenv, raw.
+                   <type>: json, toml, yaml, dotenv, compose, raw.
 
-  --export, -x     If --out=dotenv: Prepends "export " to each line.
-  --preserve, -p   If --out=dotenv: Preserves variable casing.
-  --sep=<sep>      If --out=raw:    Delimits values with a <sep>arator.
+  --export, -x     If --out=dotenv:  Prepends "export " to each line.
+  --preserve, -p   If --out=dotenv|compose: Preserves variable casing.
+  --sep=<sep>      If --out=raw:     Delimits values with a <sep>arator.
 ```
+
+## env output formats:
+
+`--out=dotenv` targets a shell: values are quoted and escaped so the file can be
+sourced. `--out=compose` targets Docker's env-file parser, which does not strip
+quotes - `KEY="value"` would reach the container with the quotes intact - so it
+writes bare `KEY=VALUE` lines with no quoting or escaping:
+
+```sh
+# shell-sourceable, values quoted and escaped
+cogs gen prod ./cog.toml --out=dotenv > .env.sh
+
+# Docker env-file: bare KEY=VALUE, consumed as-is by Compose env_file
+cogs gen prod ./cog.toml --out=compose > .env
+```
+
+Docker env-files are line oriented with no escape sequences, so a value holding
+a newline, carriage return, or NUL byte errors out naming the key rather than
+producing a silently broken file.
 
 `cogs gen` - outputs a flat and serialized K:V array
 

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Bestowinc/cogs"
 )
 
-const cogsVersion = "0.11.1"
+const cogsVersion = "0.12.0"
 const usage string = `
 COGS COnfiguration manaGement S
 
@@ -31,11 +31,11 @@ Options:
   --keys=<key,>    Include specific keys, comma separated.
   --not=<key,>     Exclude specific keys, comma separated.
   --out=<type>     Configuration output type [default: json].
-                   <type>: json, toml, yaml, dotenv, raw.
-  
-  --export, -x     If --out=dotenv: Prepends "export " to each line.
-  --preserve, -p   If --out=dotenv: Preserves variable casing.
-  --sep=<sep>      If --out=raw:    Delimits values with a <sep>arator.
+                   <type>: json, toml, yaml, dotenv, compose, raw.
+
+  --export, -x     If --out=dotenv:  Prepends "export " to each line.
+  --preserve, -p   If --out=dotenv|compose: Preserves variable casing.
+  --sep=<sep>      If --out=raw:     Delimits values with a <sep>arator.
  `
 
 // Conf is used to bind CLI arguments and options
@@ -123,6 +123,14 @@ func run() error {
 			}
 			// convert all key values to uppercase
 			output, err = godotenv.Marshal(modKeys(cfgMap, modFn...))
+			output = output + "\n"
+		case cogs.Compose:
+			var modFn []func(string) string
+			// if --preserve was called, do not convert variable names to uppercase
+			if !conf.Preserve {
+				modFn = append(modFn, strings.ToUpper)
+			}
+			output, err = cogs.MarshalCompose(modKeys(cfgMap, modFn...))
 			output = output + "\n"
 		case cogs.Raw:
 			keyList := []string{}

--- a/cmd/cogs/main.go
+++ b/cmd/cogs/main.go
@@ -32,7 +32,6 @@ Options:
   --not=<key,>     Exclude specific keys, comma separated.
   --out=<type>     Configuration output type [default: json].
                    <type>: json, toml, yaml, dotenv, compose, raw.
-
   --export, -x     If --out=dotenv:  Prepends "export " to each line.
   --preserve, -p   If --out=dotenv|compose: Preserves variable casing.
   --sep=<sep>      If --out=raw:     Delimits values with a <sep>arator.

--- a/cmd/cogs/optparse.go
+++ b/cmd/cogs/optparse.go
@@ -95,18 +95,14 @@ func (c *Conf) validate() (format cogs.Format, err error) {
 		return "", fmt.Errorf("invalid opt: --out %s", conf.Output)
 	}
 
-	switch {
-	case format != cogs.Raw:
-		if c.Delimiter != "" {
-			return "", fmt.Errorf("invalid opt: --sep")
-		}
-	case format != cogs.Dotenv:
-		if c.Export {
-			return "", fmt.Errorf("invalid opt: --export")
-		}
-		if c.Preserve {
-			return "", fmt.Errorf("invalid opt: --preserve")
-		}
+	if c.Delimiter != "" && format != cogs.Raw {
+		return "", fmt.Errorf("invalid opt: --sep")
+	}
+	if c.Export && format != cogs.Dotenv {
+		return "", fmt.Errorf("invalid opt: --export")
+	}
+	if c.Preserve && format != cogs.Dotenv && format != cogs.Compose {
+		return "", fmt.Errorf("invalid opt: --preserve")
 	}
 	return format, nil
 }

--- a/cmd/cogs/optparse_test.go
+++ b/cmd/cogs/optparse_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/Bestowinc/cogs"
+)
+
+// allowUnexported whitelists private fields for cmp.Diff comparison
+var allowUnexported cmp.Option = cmp.Exporter(func(reflect.Type) bool { return true })
+
+type validateTestOut struct {
+	name   string
+	conf   Conf
+	format cogs.Format
+	err    error
+}
+
+func TestValidate(t *testing.T) {
+	testCases := []validateTestOut{
+		{
+			name:   "NotGen",
+			conf:   Conf{Gen: false},
+			format: "",
+		},
+		{
+			name: "InvalidFormat",
+			conf: Conf{Gen: true, Output: "nope"},
+			err:  errors.New("invalid opt: --out nope"),
+		},
+		{
+			name:   "ComposeFormat",
+			conf:   Conf{Gen: true, Output: "compose"},
+			format: cogs.Compose,
+		},
+		{
+			name:   "SepWithRaw",
+			conf:   Conf{Gen: true, Output: "raw", Delimiter: ","},
+			format: cogs.Raw,
+		},
+		{
+			name: "SepWithDotenv",
+			conf: Conf{Gen: true, Output: "dotenv", Delimiter: ","},
+			err:  errors.New("invalid opt: --sep"),
+		},
+		{
+			name: "SepWithCompose",
+			conf: Conf{Gen: true, Output: "compose", Delimiter: ","},
+			err:  errors.New("invalid opt: --sep"),
+		},
+		{
+			name:   "ExportWithDotenv",
+			conf:   Conf{Gen: true, Output: "dotenv", Export: true},
+			format: cogs.Dotenv,
+		},
+		{
+			name: "ExportWithCompose",
+			conf: Conf{Gen: true, Output: "compose", Export: true},
+			err:  errors.New("invalid opt: --export"),
+		},
+		{
+			name: "ExportWithJSON",
+			conf: Conf{Gen: true, Output: "json", Export: true},
+			err:  errors.New("invalid opt: --export"),
+		},
+		{
+			name:   "PreserveWithDotenv",
+			conf:   Conf{Gen: true, Output: "dotenv", Preserve: true},
+			format: cogs.Dotenv,
+		},
+		{
+			name:   "PreserveWithCompose",
+			conf:   Conf{Gen: true, Output: "compose", Preserve: true},
+			format: cogs.Compose,
+		},
+		{
+			name: "PreserveWithYAML",
+			conf: Conf{Gen: true, Output: "yaml", Preserve: true},
+			err:  errors.New("invalid opt: --preserve"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// validate() reads the package level conf for --out
+			conf = tc.conf
+			format, err := tc.conf.validate()
+			if diff := cmp.Diff(fmt.Errorf("%s", tc.err), fmt.Errorf("%s", err), allowUnexported); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+			if tc.err != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.format, format); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/compose.go
+++ b/compose.go
@@ -1,0 +1,48 @@
+package cogs
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// composeKeyRe matches keys usable as environment variable names: Docker splits
+// each line on the first "=", so anything outside this charset yields a
+// variable the container cannot reference
+var composeKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// MarshalCompose renders a flat map as a Docker env-file: bare KEY=VALUE lines,
+// no quoting and no escaping, sorted by key. Docker's env-file parser takes
+// everything after the first "=" literally, so quotes, spaces, "#" and "$" all
+// pass through unchanged.
+//
+// Values that cannot be represented - those holding a newline, carriage return,
+// or NUL byte - return an error naming the key rather than a broken file.
+//
+// Gotcha: when the file is passed as `docker compose --env-file` (interpolation
+// into compose.yaml) rather than `env_file`, Compose expands $VAR and ${VAR} in
+// values. Escaping "$" would break the far more common env_file case, so cogs
+// does not.
+func MarshalCompose(envMap map[string]string) (string, error) {
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	lines := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if !composeKeyRe.MatchString(k) {
+			return "", fmt.Errorf("MarshalCompose: invalid key name: %q", k)
+		}
+		v := envMap[k]
+		if i := strings.IndexAny(v, "\n\r\x00"); i != -1 {
+			return "", fmt.Errorf(
+				"MarshalCompose: key %s: value contains %q, which a docker env-file cannot represent",
+				k, v[i:i+1])
+		}
+		lines = append(lines, k+"="+v)
+	}
+	return strings.Join(lines, "\n"), nil
+}

--- a/compose_test.go
+++ b/compose_test.go
@@ -1,0 +1,122 @@
+package cogs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type composeTestOut struct {
+	name   string
+	envMap map[string]string
+	output string
+	err    error
+}
+
+func TestMarshalCompose(t *testing.T) {
+	testCases := []composeTestOut{
+		{
+			name: "SimpleValues",
+			envMap: map[string]string{
+				"STR":   "value",
+				"INT":   "123",
+				"FLOAT": "1.5",
+				"BOOL":  "true",
+				"EMPTY": "",
+			},
+			output: "BOOL=true\nEMPTY=\nFLOAT=1.5\nINT=123\nSTR=value",
+		},
+		{
+			name: "NoQuotingOrEscaping",
+			envMap: map[string]string{
+				"DQUOTE":   `"quoted"`,
+				"SQUOTE":   `'quoted'`,
+				"DOLLAR":   "$FOO",
+				"BRACE":    "${FOO}",
+				"HASH":     "a # b",
+				"EQUALS":   "a=b",
+				"SPACES":   "a b c",
+				"TRAILING": "a ",
+				"BSLASH":   `a\nb`,
+				"BANG":     "a!b",
+			},
+			output: "BANG=a!b\n" +
+				`BRACE=${FOO}` + "\n" +
+				`BSLASH=a\nb` + "\n" +
+				"DOLLAR=$FOO\n" +
+				`DQUOTE="quoted"` + "\n" +
+				"EQUALS=a=b\n" +
+				"HASH=a # b\n" +
+				"SPACES=a b c\n" +
+				`SQUOTE='quoted'` + "\n" +
+				"TRAILING=a ",
+		},
+		{
+			name:   "Empty",
+			envMap: map[string]string{},
+			output: "",
+		},
+		{
+			name:   "SortOrder",
+			envMap: map[string]string{"b": "2", "A": "1", "a": "3", "_c": "4"},
+			output: "A=1\n_c=4\na=3\nb=2",
+		},
+		{
+			name:   "NewlineValue",
+			envMap: map[string]string{"MULTI": "a\nb"},
+			err:    errors.New("MarshalCompose: key MULTI: value contains \"\\n\", which a docker env-file cannot represent"),
+		},
+		{
+			name:   "CarriageReturnValue",
+			envMap: map[string]string{"MULTI": "a\rb"},
+			err:    errors.New("MarshalCompose: key MULTI: value contains \"\\r\", which a docker env-file cannot represent"),
+		},
+		{
+			name:   "NulValue",
+			envMap: map[string]string{"NUL": "a\x00b"},
+			err:    errors.New("MarshalCompose: key NUL: value contains \"\\x00\", which a docker env-file cannot represent"),
+		},
+		{
+			name:   "KeyWithEquals",
+			envMap: map[string]string{"FOO=BAR": "1"},
+			err:    errors.New(`MarshalCompose: invalid key name: "FOO=BAR"`),
+		},
+		{
+			name:   "KeyWithSpace",
+			envMap: map[string]string{"FOO BAR": "1"},
+			err:    errors.New(`MarshalCompose: invalid key name: "FOO BAR"`),
+		},
+		{
+			name:   "KeyWithLeadingDigit",
+			envMap: map[string]string{"1FOO": "1"},
+			err:    errors.New(`MarshalCompose: invalid key name: "1FOO"`),
+		},
+		{
+			name:   "EmptyKey",
+			envMap: map[string]string{"": "1"},
+			err:    errors.New(`MarshalCompose: invalid key name: ""`),
+		},
+		{
+			name:   "ExportedKey",
+			envMap: map[string]string{"export FOO": "1"},
+			err:    errors.New(`MarshalCompose: invalid key name: "export FOO"`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := MarshalCompose(tc.envMap)
+			if diff := cmp.Diff(fmt.Errorf("%s", tc.err), fmt.Errorf("%s", err), AllowUnexported); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+			if tc.err != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.output, output); diff != "" {
+				t.Errorf("(-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/e2e.sh
+++ b/e2e.sh
@@ -3,6 +3,8 @@
 go build -o ./tmp_cogs ./cmd/cogs
 ./tmp_cogs gen basic              ./examples/1.basic.cog.toml
 ./tmp_cogs gen basic              ./examples/1.basic.cog.toml --keys=var --out=toml
+./tmp_cogs gen basic              ./examples/1.basic.cog.toml --out=compose
+./tmp_cogs gen sops               ./examples/3.secrets.cog.toml --out=compose
 ./tmp_cogs gen get                ./examples/2.http.cog.toml
 ./tmp_cogs gen post               ./examples/2.http.cog.toml
 ./tmp_cogs gen post_multiple      ./examples/2.http.cog.toml

--- a/format.go
+++ b/format.go
@@ -98,17 +98,18 @@ type Format string
 
 // Formats for respective object notation
 const (
-	JSON   Format = "json"
-	YAML   Format = "yaml"
-	TOML   Format = "toml"
-	Dotenv Format = "dotenv"
-	Raw    Format = "raw"
+	JSON    Format = "json"
+	YAML    Format = "yaml"
+	TOML    Format = "toml"
+	Dotenv  Format = "dotenv"
+	Raw     Format = "raw"
+	Compose Format = "compose"
 )
 
 // Validate ensures that a string maps to a valid Format
 func (t Format) Validate() error {
 	switch t {
-	case JSON, YAML, TOML, Dotenv, Raw:
+	case JSON, YAML, TOML, Dotenv, Raw, Compose:
 		return nil
 	default: // deferred readType should not be validated
 		return fmt.Errorf("%s is an invalid Format", string(t))

--- a/output.go
+++ b/output.go
@@ -10,7 +10,7 @@ import (
 
 // OutputCfg returns the corresponding value for a given Link struct
 func OutputCfg(link *Link, outputType Format) (interface{}, error) {
-	if outputType == Dotenv || outputType == Raw {
+	if outputType == Dotenv || outputType == Raw || outputType == Compose {
 		// don't try to marshal simple primitive types
 		if IsSimpleValue(link.Value) {
 			return SimpleValueToString(link.Value)
@@ -36,7 +36,7 @@ func marshalComplexValue(v interface{}, inputType Format) (output string, err er
 			return string(b), nil
 		}
 		output = fmt.Sprintf("%s", v)
-	case Dotenv, Raw:
+	case Dotenv, Raw, Compose:
 		output = fmt.Sprintf("%s", v)
 	}
 	return output, err


### PR DESCRIPTION
Provide a way to natively output variables to an environment file in Docker Compose style. This is different than `dotenv` because it does not use `""` around the values. Thus, it gets its own output called `compose`. For example:

```sh
cogs gen prod ./cog.toml --out=compose > .env
```